### PR TITLE
Generate only notes that exists

### DIFF
--- a/src/views/Song.tsx
+++ b/src/views/Song.tsx
@@ -26,6 +26,30 @@ export const SongPage: FC<{ songs: Song[] }> = ({ songs }) => {
     return <></>;
   }
 
+  var acceptedNotesArray = [
+    'Ab',
+    'A',
+    'A#',
+    'Bb',
+    'B',
+    'B#',
+    'Cb',
+    'C',
+    'C#',
+    'Db',
+    'D',
+    'D#',
+    'Eb',
+    'E',
+    'E#',
+    'Fb',
+    'F',
+    'F#',
+    'Gb',
+    'G',
+    'G#',
+  ];
+
   return (
     <Page
       title={song ? song.title : ''}
@@ -53,14 +77,23 @@ export const SongPage: FC<{ songs: Song[] }> = ({ songs }) => {
             icon="plus"
             size="xl"
             onClick={() => {
-              const note = prompt(
-                'Write note with an octave you want to add',
-                'A4'
-              );
-              if (note === null) {
-                return;
+              const note =
+                prompt(
+                  'Write note (capital) with an octave (integer) you want to add',
+                  'Ab4'
+                ) || 'Ab4';
+              if (
+                !isNaN(Number(note.substring(note.length - 1, note.length)))
+              ) {
+                console.log(note.substring(0, note.length - 1));
+                var note_exists =
+                  acceptedNotesArray.indexOf(
+                    note.substring(0, note.length - 1)
+                  ) > -1;
+                if (note_exists) {
+                  dispatch(addNote(note, song.id));
+                }
               }
-              dispatch(addNote(note, song.id));
             }}
           />
           <ActionButton

--- a/src/views/Song.tsx
+++ b/src/views/Song.tsx
@@ -26,30 +26,6 @@ export const SongPage: FC<{ songs: Song[] }> = ({ songs }) => {
     return <></>;
   }
 
-  var acceptedNotesArray = [
-    'Ab',
-    'A',
-    'A#',
-    'Bb',
-    'B',
-    'B#',
-    'Cb',
-    'C',
-    'C#',
-    'Db',
-    'D',
-    'D#',
-    'Eb',
-    'E',
-    'E#',
-    'Fb',
-    'F',
-    'F#',
-    'Gb',
-    'G',
-    'G#',
-  ];
-
   return (
     <Page
       title={song ? song.title : ''}
@@ -82,24 +58,9 @@ export const SongPage: FC<{ songs: Song[] }> = ({ songs }) => {
                   'Write note (capital) with an octave (integer) you want to add',
                   'Ab4'
                 ) || 'Ab4';
-              var note_no_space = note.replace(/\s/g, '');
-              if (
-                !isNaN(
-                  Number(
-                    note_no_space.substring(
-                      note_no_space.length - 1,
-                      note_no_space.length
-                    )
-                  )
-                )
-              ) {
-                var note_exists =
-                  acceptedNotesArray.indexOf(
-                    note_no_space.substring(0, note_no_space.length - 1)
-                  ) > -1;
-                if (note_exists) {
-                  dispatch(addNote(note_no_space, song.id));
-                }
+              var pattern = new RegExp(/^([A-G])(b|#)?\d+$/);
+              if (pattern.test(note)) {
+                dispatch(addNote(note, song.id));
               }
             }}
           />

--- a/src/views/Song.tsx
+++ b/src/views/Song.tsx
@@ -82,16 +82,23 @@ export const SongPage: FC<{ songs: Song[] }> = ({ songs }) => {
                   'Write note (capital) with an octave (integer) you want to add',
                   'Ab4'
                 ) || 'Ab4';
+              var note_no_space = note.replace(/\s/g, '');
               if (
-                !isNaN(Number(note.substring(note.length - 1, note.length)))
+                !isNaN(
+                  Number(
+                    note_no_space.substring(
+                      note_no_space.length - 1,
+                      note_no_space.length
+                    )
+                  )
+                )
               ) {
-                console.log(note.substring(0, note.length - 1));
                 var note_exists =
                   acceptedNotesArray.indexOf(
-                    note.substring(0, note.length - 1)
+                    note_no_space.substring(0, note_no_space.length - 1)
                   ) > -1;
                 if (note_exists) {
-                  dispatch(addNote(note, song.id));
+                  dispatch(addNote(note_no_space, song.id));
                 }
               }
             }}


### PR DESCRIPTION
Not formaly an issue!

Previously, a note was added even though it did not represent an actual note. This pull request fixes it by checking if the note from the prompt is an acceptable note.

Prompt gives a string -> Removes the whitespaces (compatible with user errors) -> Check the octave (is an integer?) -> Compare note to an array of acceptable notes.

[Test]
Login -> Chose a setlist -> Edit a song -> Add a note
 - Type it correct -> Note is created
 - Type it incorrect -> Note is not created
