### PR TITLE
Add note dialogue

### DIFF
--- a/src/views/Song.tsx
+++ b/src/views/Song.tsx
@@ -57,10 +57,9 @@ export const SongPage: FC<{ songs: Song[] }> = ({ songs }) => {
                 'Write note with an octave you want to add',
                 'A4'
               );
-              if (note === null) {
-                return;
+              if (note !== null) {
+                dispatch(addNote(note, song.id));
               }
-              dispatch(addNote(note, song.id));
             }}
           />
           <ActionButton


### PR DESCRIPTION
#60 

By choosing "cancel" in the dialogue of creating a new note does no longer create the note.

[Test]
Edit a song -> press cancel -> No note added
Edit a song -> Press ok -> Note added